### PR TITLE
Only transpose likelihood matrix if `n_locs` > 1

### DIFF
--- a/R/AMIS_steps.R
+++ b/R/AMIS_steps.R
@@ -87,12 +87,20 @@ compute_weight_matrix <- function(likelihoods, simulated_prevalence, amis_params
   n_locs <- dim(likelihoods)[2]
   n_sims <- dim(likelihoods)[3]
   weight_matrix <- matrix(rep(first_weight,n_locs), nrow = n_sims, ncol = n_locs)
+  ## If n_locs = 1, likelihood matrix for given timepoint is an atomic
+  ## vector and doesn't need to be transposed.
+  if (n_locs == 1) {
+    lik_matrix <- function(l) as.matrix(l)
+  } else {
+    lik_matrix <- function(l) t(l)
+  }
   for (t in 1:n_tims) {
+    lik_mat <- lik_matrix(likelihoods[t,,])
     # Update the weights by the latest likelihood (filtering)
     if (is.null(amis_params[["breaks"]])) {
-      weight_matrix <- compute_weight_matrix_empirical(t(likelihoods[t,,]),simulated_prevalence[,t],amis_params,weight_matrix)
+      weight_matrix <- compute_weight_matrix_empirical(lik_mat,simulated_prevalence[,t],amis_params,weight_matrix)
     } else {
-      weight_matrix <- compute_weight_matrix_histogram(t(likelihoods[t,,]),simulated_prevalence[,t],amis_params,weight_matrix)
+      weight_matrix <- compute_weight_matrix_histogram(lik_mat,simulated_prevalence[,t],amis_params,weight_matrix)
     }
   }
   # renormalise weights


### PR DESCRIPTION
If `n_locs = 1` the likelihood matrix passed to `compute_weight_empirical` from `compute_weight_matrix` has the wrong shape (`n_sims * n_locs`)

### Issue

1. Variable `likelihood` is defined as an array of size `tsims` x `nlocs` x `nsims` in `compute_likelihood`.
2. Function `compute_weight_matrix` passes the transpose of a section of the likelihood array to the specialised function that compute the weight matrix:
``` R
for (t in 1:n_tims) {
    # Update the weights by the latest likelihood (filtering)
    if (is.null(amis_params[["breaks"]])) {
        weight_matrix <- compute_weight_matrix_empirical(t(likelihoods[t,,]),simulated_prevalence[,t],amis_params,weight_matrix)
    } else {
```
3. If `n_locs = 1`, then `likelihoods[1,,]` is not a `n_locs x n_sims` matrix, but a vector of length `n_sims`. Its transpose is a matrix of size `1 x n_sims`, but the `compute_weight_matrix_empirical` expects a matrix of size `n_sims x n_locs` (`n_sims x 1` in this
case).

### Fix

If `n_locs =1`, `likelihoods[t,,]` is an atomic vector of length `n_sims`. Instead of transposing it (which would generate a matrix of the wrong dimensions), the matrix can be generated with `as.matrix`. We end up with a conditional before looping on timepoints
```R
if (n_locs == 1) {
    lik_matrix <- function(l) as.matrix(l)
  } else {
    lik_matrix <- function(l) t(l)
  }
for (t in 1:n_tims) {
    lik_mat <- lik_matrix(likelihoods[t,,])
```

Likely to be a better way of dealing with the issue, but this seemed to me like a good way to fix the issue without causing too much collateral change.